### PR TITLE
added pattern capability for expressing usages

### DIFF
--- a/lib/mix_unused/analyzers/unreachable/config.ex
+++ b/lib/mix_unused/analyzers/unreachable/config.ex
@@ -2,11 +2,11 @@ defmodule MixUnused.Analyzers.Unreachable.Config do
   @moduledoc """
   Configuration specific to the [Unreachable](`MixUnused.Analyzers.Unreachable`) analyzer.
   """
-
+  alias MixUnused.Filter
   alias __MODULE__, as: Config
 
   @type t :: %Config{
-          usages: [module() | mfa()],
+          usages: [Filter.mfa_pattern()],
           usages_discovery: [module()],
           report_transitively_unused: boolean()
         }

--- a/lib/mix_unused/analyzers/unreachable/config.ex
+++ b/lib/mix_unused/analyzers/unreachable/config.ex
@@ -6,7 +6,7 @@ defmodule MixUnused.Analyzers.Unreachable.Config do
   alias __MODULE__, as: Config
 
   @type t :: %Config{
-          usages: [Filter.mfa_pattern()],
+          usages: [Filter.pattern()],
           usages_discovery: [module()],
           report_transitively_unused: boolean()
         }

--- a/lib/mix_unused/analyzers/unreachable/usages.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages.ex
@@ -47,8 +47,8 @@ defmodule MixUnused.Analyzers.Unreachable.Usages do
   end
 
   @spec declared_usages([Filter.pattern()], Exports.t()) :: [mfa()]
-  defp declared_usages(hints, exports) do
-    Filter.filter_matching(exports, hints) |> Enum.map(fn {mfa, _} -> mfa end)
+  defp declared_usages(patterns, exports) do
+    Filter.filter_matching(exports, patterns) |> Map.keys()
   end
 
   @spec discovered_usages([module()], Exports.t()) :: [mfa()]

--- a/lib/mix_unused/analyzers/unreachable/usages.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages.ex
@@ -4,8 +4,9 @@ defmodule MixUnused.Analyzers.Unreachable.Usages do
   """
 
   alias MixUnused.Analyzers.Unreachable.Config
-  alias MixUnused.Exports
   alias MixUnused.Debug
+  alias MixUnused.Exports
+  alias MixUnused.Filter
 
   @type context :: [
           exports: Exports.t()
@@ -45,12 +46,9 @@ defmodule MixUnused.Analyzers.Unreachable.Usages do
     Debug.debug(modules, &debug/1)
   end
 
-  @spec declared_usages([module() | mfa()], Exports.t()) :: [mfa()]
+  @spec declared_usages([Filter.mfa_pattern()], Exports.t()) :: [mfa()]
   defp declared_usages(hints, exports) do
-    Enum.flat_map(hints, fn
-      {m, f, a} -> [{m, f, a}]
-      m -> for {^m, f, a} <- Map.keys(exports), do: {m, f, a}
-    end)
+    Filter.filter_matching(exports, hints) |> Enum.map(fn {mfa, _} -> mfa end)
   end
 
   @spec discovered_usages([module()], Exports.t()) :: [mfa()]

--- a/lib/mix_unused/analyzers/unreachable/usages.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages.ex
@@ -46,7 +46,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages do
     Debug.debug(modules, &debug/1)
   end
 
-  @spec declared_usages([Filter.mfa_pattern()], Exports.t()) :: [mfa()]
+  @spec declared_usages([Filter.pattern()], Exports.t()) :: [mfa()]
   defp declared_usages(hints, exports) do
     Filter.filter_matching(exports, hints) |> Enum.map(fn {mfa, _} -> mfa end)
   end

--- a/lib/mix_unused/filter.ex
+++ b/lib/mix_unused/filter.ex
@@ -24,26 +24,20 @@ defmodule MixUnused.Filter do
   @spec reject_matching(exports :: Exports.t(), patterns :: [pattern()]) ::
           Exports.t()
   def reject_matching(exports, patterns) do
-    filters = normalize_filter_patterns(patterns)
-
-    Enum.reject(exports, fn {func, meta} ->
-      Enum.any?(filters, &mfa_match?(&1, func, meta))
-    end)
-    |> Map.new()
+    Map.reject(exports, matcher(patterns))
   end
 
-  @doc """
-  Get values in `exports` that match any pattern in `patterns`
-  """
   @spec filter_matching(exports :: Exports.t(), patterns :: [pattern()]) ::
           Exports.t()
   def filter_matching(exports, patterns) do
+    Map.filter(exports, matcher(patterns))
+  end
+
+  @spec matcher(patterns :: [pattern()]) :: ({mfa(), Meta.t()} -> boolean())
+  defp matcher(patterns) do
     filters = normalize_filter_patterns(patterns)
 
-    Enum.filter(exports, fn {func, meta} ->
-      Enum.any?(filters, &mfa_match?(&1, func, meta))
-    end)
-    |> Map.new()
+    fn {mfa, meta} -> Enum.any?(filters, &mfa_match?(&1, mfa, meta)) end
   end
 
   @spec normalize_filter_patterns(patterns :: [pattern()]) :: [pattern()]

--- a/test/fixtures/unreachable/lib/simple_module.ex
+++ b/test/fixtures/unreachable/lib/simple_module.ex
@@ -7,4 +7,12 @@ defmodule SimpleModule do
   def use_foo(struct), do: SimpleStruct.foo(struct) == @answer
 
   def used_from_unused, do: f()
+
+  def public_unused, do: f()
+
+  def public_used_by_unused_private, do: f()
+
+  defp private_unused do
+    public_used_by_unused_private()
+  end
 end

--- a/test/mix_unused/analyzers/unreachable_test.exs
+++ b/test/mix_unused/analyzers/unreachable_test.exs
@@ -29,21 +29,27 @@ defmodule MixUnused.Analyzers.UnreachableTest do
              @subject.analyze(calls, %{function => %Meta{}}, %{})
   end
 
-  test "patterns" do
+  test "testing usages defined as patterns capabilities" do
     functions = %{
       {Foo, :a, 1} => %Meta{},
       {Foo, :a, 2} => %Meta{},
       {Foo, :b, 1} => %Meta{},
       {Foo, :b, 4} => %Meta{},
       {Bar, :a, 1} => %Meta{},
-      {Bar, :d, 1} => %Meta{}
+      {Bar, :d, 1} => %Meta{},
+      {Rab, :b, 5} => %Meta{},
+      {Bob, :z, 1} => %Meta{},
+      {Bob, :z, 6} => %Meta{}
     }
 
     calls = %{Foo => [{{Foo, :a, 1}, %{caller: {:b, 1}}}]}
 
-    assert %{} ==
+    assert %{{Foo, :a, 2} => %Meta{}, {Bob, :z, 6} => %Meta{}} ==
              @subject.analyze(calls, functions, %{
-               usages: [{~r/\S/, :_, 1..5}]
+               usages: [
+                 {~r/B\S/, :_, 1..5},
+                 {:_, :b, :_}
+               ]
              })
   end
 

--- a/test/mix_unused/analyzers/unreachable_test.exs
+++ b/test/mix_unused/analyzers/unreachable_test.exs
@@ -11,17 +11,43 @@ defmodule MixUnused.Analyzers.UnreachableTest do
     assert %{} == @subject.analyze(%{}, %{}, %{})
   end
 
-  test "called externally but undeclared" do
+  test "called only by unused private function (not in the exported set), with transitive reported" do
+    function = {Foo, :a, 1}
+    calls = %{Bar => [{function, %{caller: {:b, 1}}}]}
+
+    assert %{{Foo, :a, 1} => %Meta{}} ==
+             @subject.analyze(calls, %{function => %Meta{}}, %{
+               report_transitively_unused: true
+             })
+  end
+
+  test "called only by unused private function (not in the exported set), default" do
     function = {Foo, :a, 1}
     calls = %{Bar => [{function, %{caller: {:b, 1}}}]}
 
     assert %{} ==
-             @subject.analyze(calls, %{function => %Meta{}}, %{
-               usages: [{Bar, :b, 1}]
+             @subject.analyze(calls, %{function => %Meta{}}, %{})
+  end
+
+  test "patterns" do
+    functions = %{
+      {Foo, :a, 1} => %Meta{},
+      {Foo, :a, 2} => %Meta{},
+      {Foo, :b, 1} => %Meta{},
+      {Foo, :b, 4} => %Meta{},
+      {Bar, :a, 1} => %Meta{},
+      {Bar, :d, 1} => %Meta{}
+    }
+
+    calls = %{Foo => [{{Foo, :a, 1}, %{caller: {:b, 1}}}]}
+
+    assert %{} ==
+             @subject.analyze(calls, functions, %{
+               usages: [{~r/\S/, :_, 1..5}]
              })
   end
 
-  test "called internally and externally" do
+  test "called by exported and not exported (i.e. private) functions" do
     function_a = {Foo, :a, 1}
     function_b = {Foo, :b, 1}
 
@@ -36,9 +62,7 @@ defmodule MixUnused.Analyzers.UnreachableTest do
     }
 
     assert %{} ==
-             @subject.analyze(calls, functions, %{
-               usages: [{Bar, :c, 1}]
-             })
+             @subject.analyze(calls, functions, %{})
   end
 
   test "called only internally" do
@@ -60,7 +84,7 @@ defmodule MixUnused.Analyzers.UnreachableTest do
              })
   end
 
-  test "transitively unused functions are reported when the related is enabled" do
+  test "transitively unused functions are reported when the related option is enabled" do
     function_a = {Foo, :a, 1}
     function_b = {Foo, :b, 1}
 


### PR DESCRIPTION
added capability for defining usages as patterns (both `Regex` or in the form `{module, :_, 1..5}` and combinations (see filter.ex for details)