### PR TITLE
ft: discover functions called by Exq

### DIFF
--- a/lib/mix_unused/analyzers/unreachable.ex
+++ b/lib/mix_unused/analyzers/unreachable.ex
@@ -17,7 +17,10 @@ defmodule MixUnused.Analyzers.Unreachable do
   def analyze(data, exports, config) do
     config = Config.cast(config)
     graph = Calls.calls_graph(data, exports)
-    usages = Usages.usages(config, exports)
+
+    usages =
+      Usages.usages(config, %Usages.Context{calls: graph, exports: exports})
+
     reachables = graph |> Graph.reachable(usages) |> MapSet.new()
     called_at_compile_time = Calls.called_at_compile_time(data, exports)
 

--- a/lib/mix_unused/analyzers/unreachable/usages.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages.ex
@@ -3,14 +3,21 @@ defmodule MixUnused.Analyzers.Unreachable.Usages do
   Provides the starting points for the [Unreachable](`MixUnused.Analyzers.Unreachable`) analyzer.
   """
 
+  alias MixUnused.Analyzers.Calls
   alias MixUnused.Analyzers.Unreachable.Config
   alias MixUnused.Debug
   alias MixUnused.Exports
   alias MixUnused.Filter
 
-  @type context :: [
-          exports: Exports.t()
-        ]
+  defmodule Context do
+    @moduledoc false
+
+    @type t :: %__MODULE__{
+            calls: Calls.t(),
+            exports: Exports.t()
+          }
+    defstruct [:calls, :exports]
+  end
 
   @doc """
   Called during the analysis to search potential used functions.
@@ -18,47 +25,48 @@ defmodule MixUnused.Analyzers.Unreachable.Usages do
   It receives the map of all the exported functions and returns
   the list of found functions.
   """
-  @callback discover_usages(context()) :: [mfa()]
+  @callback discover_usages(Context.t()) :: [mfa()]
 
   @default_discoveries [
     MixUnused.Analyzers.Unreachable.Usages.AbsintheDiscovery,
     MixUnused.Analyzers.Unreachable.Usages.AmqpxConsumersDiscovery,
+    MixUnused.Analyzers.Unreachable.Usages.ExqDiscovery,
     MixUnused.Analyzers.Unreachable.Usages.HttpMockPalDiscovery,
     MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscovery,
     MixUnused.Analyzers.Unreachable.Usages.SupervisorDiscovery,
     MixUnused.Analyzers.Unreachable.Usages.VmstatsDiscovery
   ]
 
-  @spec usages(Config.t(), Exports.t()) :: [mfa()]
+  @spec usages(Config.t(), Context.t()) :: [mfa()]
   def usages(
         %Config{
           usages: usages,
           usages_discovery: usages_discovery
         },
-        exports
+        context
       ) do
     modules =
       Enum.concat(
-        declared_usages(usages, exports),
-        discovered_usages(usages_discovery ++ @default_discoveries, exports)
+        declared_usages(usages, context),
+        discovered_usages(usages_discovery ++ @default_discoveries, context)
       )
 
     Debug.debug(modules, &debug/1)
   end
 
-  @spec declared_usages([Filter.pattern()], Exports.t()) :: [mfa()]
-  defp declared_usages(patterns, exports) do
+  @spec declared_usages([Filter.pattern()], Context.t()) :: [mfa()]
+  defp declared_usages(patterns, %Context{exports: exports}) do
     Filter.filter_matching(exports, patterns) |> Map.keys()
   end
 
-  @spec discovered_usages([module()], Exports.t()) :: [mfa()]
-  defp discovered_usages(modules, exports) do
+  @spec discovered_usages([module()], Context.t()) :: [mfa()]
+  defp discovered_usages(modules, context) do
     for module <- modules do
       [
         # the module is itself an used module since it
         # could call functions created specifically for it
         {module, :discover_usages, 1}
-        | apply(module, :discover_usages, [[exports: exports]])
+        | apply(module, :discover_usages, [context])
       ]
     end
     |> List.flatten()

--- a/lib/mix_unused/analyzers/unreachable/usages/amqpx_consumers_discovery.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages/amqpx_consumers_discovery.ex
@@ -6,7 +6,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.AmqpxConsumersDiscovery do
   @behaviour MixUnused.Analyzers.Unreachable.Usages
 
   @impl true
-  def discover_usages(_opts) do
+  def discover_usages(_context) do
     app = Mix.Project.config()[:app]
 
     for %{handler_module: module} <- Application.get_env(app, :consumers, []) do

--- a/lib/mix_unused/analyzers/unreachable/usages/exq_discovery.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages/exq_discovery.ex
@@ -1,0 +1,73 @@
+defmodule MixUnused.Analyzers.Unreachable.Usages.ExqDiscovery do
+  @moduledoc """
+  Discovers functions called by [Exq](https://hex.pm/packages/exq).
+  """
+
+  alias MixUnused.Analyzers.Unreachable.Usages.Context
+  alias MixUnused.Analyzers.Unreachable.Usages.Helpers.Aliases
+  alias MixUnused.Analyzers.Unreachable.Usages.Helpers.Source
+
+  @behaviour MixUnused.Analyzers.Unreachable.Usages
+
+  @impl true
+  def discover_usages(%Context{calls: calls, exports: exports}) do
+    for module <- modules_calling_exq(calls),
+        source <- Source.read_module_source(module, exports),
+        mfa <- functions_called_by_exq(source),
+        uniq: true,
+        do: mfa
+  end
+
+  defp modules_calling_exq(calls) do
+    for m <- [Exq, Exq.Enqueuer],
+        {f, a} <- [
+          {:enqueue, 4},
+          {:enqueue_at, 5},
+          {:enqueue_in, 5}
+        ],
+        # every function has an additional optional argument
+        a <- [a, a + 1],
+        %Graph.Edge{v1: {caller, _f, _a}} <- Graph.in_edges(calls, {m, f, a}),
+        do: caller
+  end
+
+  defp functions_called_by_exq(ast) do
+    aliases = Aliases.new(ast)
+
+    for node <- Macro.prewalker(ast),
+        {module, ariety} <- [function_called_by_exq(node)],
+        {:ok, module} <- [Aliases.resolve(aliases, module)],
+        do: {module, :perform, ariety}
+  end
+
+  defp function_called_by_exq(ast) do
+    case ast do
+      # Exq.enqueue(pid, queue, worker, ...)
+      {{:., _, [{:__aliases__, _, [:Exq | _]}, :enqueue]}, _,
+       [
+         _pid,
+         _queue,
+         _worker = module,
+         args | _
+       ]}
+      when is_list(args) ->
+        {module, length(args)}
+
+      # Exq.enqueue_at(pid, queue, time, worker, ...)
+      # Exq.enqueue_in(pid, queue, offset, worker, ...)
+      {{:., _, [{:__aliases__, _, [:Exq | _]}, f]}, _,
+       [
+         _pid,
+         _queue,
+         _time_or_offset,
+         _worker = module,
+         args | _
+       ]}
+      when f in [:enqueue_at, :enqueue_in] and is_list(args) ->
+        {module, length(args)}
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/mix_unused/analyzers/unreachable/usages/http_mock_pal_discovery.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages/http_mock_pal_discovery.ex
@@ -6,7 +6,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.HttpMockPalDiscovery do
   @behaviour MixUnused.Analyzers.Unreachable.Usages
 
   @impl true
-  def discover_usages(_opts) do
+  def discover_usages(_context) do
     for {module, _} <- Application.get_env(:http_mock_pal, :routers, []) do
       {module, :call, 2}
     end

--- a/lib/mix_unused/analyzers/unreachable/usages/phoenix_discovery.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages/phoenix_discovery.ex
@@ -32,8 +32,9 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscovery do
   @behaviour MixUnused.Analyzers.Unreachable.Usages
 
   @http_methods [
-    :get,
+    :delete,
     :forward,
+    :get,
     :options,
     :patch,
     :post,
@@ -59,7 +60,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscovery do
 
   defp functions_called_by_router(ast) do
     case ast do
-      {method, _, [_path, module, f]}
+      {method, _, [_path, module, f | _]}
       when method in @http_methods and is_atom(f) ->
         [{module, f, 2}]
 

--- a/lib/mix_unused/analyzers/unreachable/usages/phoenix_discovery.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages/phoenix_discovery.ex
@@ -32,13 +32,15 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscovery do
   @behaviour MixUnused.Analyzers.Unreachable.Usages
 
   @http_methods [
+    :connect,
     :delete,
     :forward,
     :get,
+    :head,
     :options,
     :patch,
     :post,
-    :put
+    :trace
   ]
 
   @impl true

--- a/lib/mix_unused/analyzers/unreachable/usages/phoenix_discovery.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages/phoenix_discovery.ex
@@ -25,6 +25,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscovery do
   Note: generally plugs are defined inside pipelines, but the discovery module currently does not check if a pipeline is actually used.
   """
 
+  alias MixUnused.Analyzers.Unreachable.Usages.Context
   alias MixUnused.Analyzers.Unreachable.Usages.Helpers.Aliases
   alias MixUnused.Analyzers.Unreachable.Usages.Helpers.Source
 
@@ -40,30 +41,33 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscovery do
   ]
 
   @impl true
-  def discover_usages(exports: exports) do
-    "router.ex"
-    |> Source.read_sources_with_suffix(exports)
-    |> Enum.flat_map(&analyze/1)
+  def discover_usages(%Context{exports: exports}) do
+    for source <- Source.read_sources_with_suffix("router.ex", exports),
+        mfa <- analyze(source),
+        uniq: true,
+        do: mfa
   end
 
   defp analyze(ast) do
     aliases = Aliases.new(ast)
 
-    for node <- Macro.prewalker(ast) do
-      case node do
-        {method, _, [_path, {:__aliases__, _, atoms}, f]}
-        when method in @http_methods and is_atom(f) ->
-          module = Aliases.resolve(aliases, atoms)
-          [{module, f, 2}]
+    for node <- Macro.prewalker(ast),
+        {m, f, a} <- functions_called_by_router(node),
+        {:ok, m} <- [Aliases.resolve(aliases, m)],
+        do: {m, f, a}
+  end
 
-        {:plug, _, [{:__aliases__, _, atoms} | _]} ->
-          module = Aliases.resolve(aliases, atoms)
-          [{module, :init, 1}, {module, :call, 2}]
+  defp functions_called_by_router(ast) do
+    case ast do
+      {method, _, [_path, module, f]}
+      when method in @http_methods and is_atom(f) ->
+        [{module, f, 2}]
 
-        _ ->
-          []
-      end
+      {:plug, _, [module | _]} ->
+        [{module, :init, 1}, {module, :call, 2}]
+
+      _ ->
+        []
     end
-    |> List.flatten()
   end
 end

--- a/lib/mix_unused/analyzers/unreachable/usages/supervisor_discovery.ex
+++ b/lib/mix_unused/analyzers/unreachable/usages/supervisor_discovery.ex
@@ -32,12 +32,13 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.SupervisorDiscovery do
   * it currently does not resolve aliases, for this reason the `Supervisor` itself is not detected in the example above.
   """
 
+  alias MixUnused.Analyzers.Unreachable.Usages.Context
   alias MixUnused.Analyzers.Unreachable.Usages.Helpers.Source
 
   @behaviour MixUnused.Analyzers.Unreachable.Usages
 
   @impl true
-  def discover_usages(exports: exports) do
+  def discover_usages(%Context{exports: exports}) do
     "supervisor.ex"
     |> Source.read_sources_with_suffix(exports)
     |> Enum.flat_map(&analyze(&1, exports))

--- a/lib/mix_unused/calls.ex
+++ b/lib/mix_unused/calls.ex
@@ -6,11 +6,13 @@ defmodule MixUnused.Analyzers.Calls do
   alias MixUnused.Meta
   alias MixUnused.Tracer
 
+  @type t :: Graph.t()
+
   @doc """
   Creates a graph where each node is a function and an edge from `f` to `g`
   means that the function `f` calls `g`.
   """
-  @spec calls_graph(Tracer.data(), Exports.t()) :: Graph.t()
+  @spec calls_graph(Tracer.data(), Exports.t()) :: t()
   def calls_graph(data, exports) do
     Graph.new(type: :directed)
     |> add_calls(data)

--- a/test/mix_unused/analyzers/unreachable/usages/absinthe_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/absinthe_discovery_test.exs
@@ -1,6 +1,7 @@
 defmodule MixUnused.Analyzers.Unreachable.Usages.AbsintheDiscoveryTest do
   use ExUnit.Case
 
+  alias MixUnused.Analyzers.Unreachable.Usages.Context
   alias MixUnused.Analyzers.Unreachable.Usages.AbsintheDiscovery
   alias MixUnused.Meta
 
@@ -19,7 +20,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.AbsintheDiscoveryTest do
         ]
       end do
       usages =
-        AbsintheDiscovery.discover_usages(
+        AbsintheDiscovery.discover_usages(%Context{
           exports: %{
             {Schema, :__absinthe_function__, 1} => %Meta{
               file: "schema.ex"
@@ -28,7 +29,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.AbsintheDiscoveryTest do
               file: "types.ex"
             }
           }
-        )
+        })
 
       assert {Schema, :__absinthe_function__, 1} in usages
       assert {Schema.Types, :__absinthe_function__, 1} in usages
@@ -72,7 +73,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.AbsintheDiscoveryTest do
         ]
       end do
       usages =
-        AbsintheDiscovery.discover_usages(
+        AbsintheDiscovery.discover_usages(%Context{
           exports: %{
             {Schema, :__absinthe_function__, 1} => %Meta{
               file: "schema.ex"
@@ -81,7 +82,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.AbsintheDiscoveryTest do
               file: "types.ex"
             }
           }
-        )
+        })
 
       assert {App.GraphQL.Logger, :call, 2} in usages
       assert {App.GraphQL.Authorization.RequirePermission, :call, 2} in usages

--- a/test/mix_unused/analyzers/unreachable/usages/amqpx_consumers_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/amqpx_consumers_discovery_test.exs
@@ -25,7 +25,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.AmqpxConsumersDiscoveryTest do
          end
        ]}
     ] do
-      usages = AmqpxConsumersDiscovery.discover_usages(any: "this is unused")
+      usages = AmqpxConsumersDiscovery.discover_usages(nil)
 
       assert {MyApplication.MyFirstConsumer, :setup, 1} in usages
       assert {MyApplication.MyFirstConsumer, :handle_message, 3} in usages
@@ -45,7 +45,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.AmqpxConsumersDiscoveryTest do
          end
        ]}
     ] do
-      usages = AmqpxConsumersDiscovery.discover_usages(any: "this is unused")
+      usages = AmqpxConsumersDiscovery.discover_usages(nil)
 
       assert usages == []
     end

--- a/test/mix_unused/analyzers/unreachable/usages/exq_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/exq_discovery_test.exs
@@ -1,0 +1,90 @@
+defmodule MixUnused.Analyzers.Unreachable.Usages.ExqDiscoveryTest do
+  use ExUnit.Case
+
+  alias MixUnused.Analyzers.Unreachable.Usages.Context
+  alias MixUnused.Analyzers.Unreachable.Usages.ExqDiscovery
+  alias MixUnused.Meta
+
+  import Mock
+
+  test "it discovers functions called by Exq (via enqueue)" do
+    with_mock File,
+      read!: fn
+        "example.ex" -> ~s{
+            defmodule Example do
+              alias Example.Consumer
+
+              def f do
+                Exq.enqueue(Exq, "queue", Consumer, [1, 2])
+              end
+            end
+          }
+      end do
+      usages =
+        ExqDiscovery.discover_usages(%Context{
+          calls:
+            Graph.new()
+            |> Graph.add_edge({Example, :f, 0}, {Exq, :enqueue, 4}),
+          exports: %{
+            {Example, :f, 0} => %Meta{file: "example.ex"}
+          }
+        })
+
+      assert [{Example.Consumer, :perform, 2}] == usages
+    end
+  end
+
+  test "it discovers functions called by Exq (via enqueue_in)" do
+    with_mock File,
+      read!: fn
+        "example.ex" -> ~s{
+            defmodule Example do
+              alias Example.Consumer
+
+              def f do
+                Exq.enqueue_in(Exq, "queue", 1000, Consumer, [1], max_retries: 2)
+              end
+            end
+          }
+      end do
+      usages =
+        ExqDiscovery.discover_usages(%Context{
+          calls:
+            Graph.new()
+            |> Graph.add_edge({Example, :f, 0}, {Exq, :enqueue_in, 6}),
+          exports: %{
+            {Example, :f, 0} => %Meta{file: "example.ex"}
+          }
+        })
+
+      assert [{Example.Consumer, :perform, 1}] == usages
+    end
+  end
+
+  test "it discovers functions called by Exq (via enqueue_at)" do
+    with_mock File,
+      read!: fn
+        "example.ex" -> ~s{
+            defmodule Example do
+              alias Example.Consumer
+
+              def f do
+                Exq.Enqueuer.enqueue_at(Exq.Enqueuer, "queue", DateTime.now(), __MODULE__, [])
+              end
+            end
+          }
+      end do
+      usages =
+        ExqDiscovery.discover_usages(%Context{
+          calls:
+            Graph.new()
+            |> Graph.add_edge({Example, :f, 0}, {Exq, :enqueue_at, 5}),
+          exports: %{
+            {Example, :f, 0} => %Meta{file: "example.ex"}
+          }
+        })
+
+      assert [{Example, :perform, 0}] == usages
+    end
+  end
+end

--- a/test/mix_unused/analyzers/unreachable/usages/helpers/aliases_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/helpers/aliases_test.exs
@@ -15,12 +15,12 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.Helpers.AliasesTest do
         end
       )
 
-    assert Aliases.resolve(aliases, [:A]) == A
-    assert Aliases.resolve(aliases, [:B]) == A.B
-    assert Aliases.resolve(aliases, [:C]) == A.B.C
-    assert Aliases.resolve(aliases, [:B, :C]) == A.B.C
-    assert Aliases.resolve(aliases, [:A, :D]) == A.D
-    assert Aliases.resolve(aliases, [:C, :D]) == A.B.C.D
+    assert Aliases.resolve(aliases, alias_node([:A])) == {:ok, A}
+    assert Aliases.resolve(aliases, alias_node([:B])) == {:ok, A.B}
+    assert Aliases.resolve(aliases, alias_node([:C])) == {:ok, A.B.C}
+    assert Aliases.resolve(aliases, alias_node([:B, :C])) == {:ok, A.B.C}
+    assert Aliases.resolve(aliases, alias_node([:A, :D])) == {:ok, A.D}
+    assert Aliases.resolve(aliases, alias_node([:C, :D])) == {:ok, A.B.C.D}
   end
 
   test "it is able to resolve :as aliases" do
@@ -35,35 +35,68 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.Helpers.AliasesTest do
         end
       )
 
-    assert Aliases.resolve(aliases, [:A]) == A
-    assert Aliases.resolve(aliases, [:B]) == B
-    assert Aliases.resolve(aliases, [:Foo]) == A.B
-    assert Aliases.resolve(aliases, [:C]) == A.B.C
-    assert Aliases.resolve(aliases, [:Foo, :C]) == A.B.C
-    assert Aliases.resolve(aliases, [:A, :D]) == A.D
+    assert Aliases.resolve(aliases, alias_node([:A])) == {:ok, A}
+    assert Aliases.resolve(aliases, alias_node([:B])) == {:ok, B}
+    assert Aliases.resolve(aliases, alias_node([:Foo])) == {:ok, A.B}
+    assert Aliases.resolve(aliases, alias_node([:C])) == {:ok, A.B.C}
+    assert Aliases.resolve(aliases, alias_node([:Foo, :C])) == {:ok, A.B.C}
+    assert Aliases.resolve(aliases, alias_node([:A, :D])) == {:ok, A.D}
   end
 
   test "resolving on an empty ast returns the name as is" do
-    aliases =
-      Aliases.new(
-        quote do
-        end
-      )
+    aliases = Aliases.new(nil)
 
-    assert Aliases.resolve(aliases, [:A]) == A
-    assert Aliases.resolve(aliases, [:B]) == B
-    assert Aliases.resolve(aliases, [:C]) == C
-    assert Aliases.resolve(aliases, [:B, :C]) == B.C
-    assert Aliases.resolve(aliases, [:A, :D]) == A.D
+    assert Aliases.resolve(aliases, alias_node([:A])) == {:ok, A}
+    assert Aliases.resolve(aliases, alias_node([:B])) == {:ok, B}
+    assert Aliases.resolve(aliases, alias_node([:C])) == {:ok, C}
+    assert Aliases.resolve(aliases, alias_node([:B, :C])) == {:ok, B.C}
+    assert Aliases.resolve(aliases, alias_node([:A, :D])) == {:ok, A.D}
   end
 
   test "a resolve on an empty atom list returns Elixir" do
+    aliases = Aliases.new(nil)
+    assert Aliases.resolve(aliases, alias_node([])) == {:ok, Elixir}
+  end
+
+  test "a resolve on an unsupported ast returns error" do
+    aliases = Aliases.new(nil)
+    assert Aliases.resolve(aliases, nil) == :error
+  end
+
+  test "it resolves unique aliases from nested modules" do
     aliases =
       Aliases.new(
         quote do
+          defmodule A.B.C do
+            alias A.B
+
+            defmodule D do
+              alias A.B.C
+              # ignored since already defined at top level
+              alias B2, as: B
+            end
+          end
         end
       )
 
-    assert Aliases.resolve(aliases, []) == Elixir
+    assert Aliases.resolve(aliases, alias_node([:B])) == {:ok, A.B}
+    assert Aliases.resolve(aliases, alias_node([:C])) == {:ok, A.B.C}
   end
+
+  test "it resolves __MODULE__ to the top level module" do
+    aliases =
+      Aliases.new(
+        quote do
+          defmodule A.B.C do
+            defmodule D do
+            end
+          end
+        end
+      )
+
+    assert Aliases.resolve(aliases, __module__node()) == {:ok, A.B.C}
+  end
+
+  defp alias_node(atoms), do: {:__aliases__, [], atoms}
+  defp __module__node, do: {:__MODULE__, [], Elixir}
 end

--- a/test/mix_unused/analyzers/unreachable/usages/http_mock_pal_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/http_mock_pal_discovery_test.exs
@@ -14,7 +14,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.HttpMockPalDiscoveryTest do
             {MySecondMock, port: 8000}
           ]
       end do
-      usages = HttpMockPalDiscovery.discover_usages(any: "this is unused")
+      usages = HttpMockPalDiscovery.discover_usages(nil)
 
       assert {MyFirstMock, :call, 2} in usages
       assert {MySecondMock, :call, 2} in usages
@@ -27,7 +27,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.HttpMockPalDiscoveryTest do
       get_env: fn
         :http_mock_pal, :routers, [] -> []
       end do
-      usages = HttpMockPalDiscovery.discover_usages(any: "this is unused")
+      usages = HttpMockPalDiscovery.discover_usages(nil)
 
       assert usages == []
     end

--- a/test/mix_unused/analyzers/unreachable/usages/phoenix_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/phoenix_discovery_test.exs
@@ -1,12 +1,12 @@
 defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscoveryTest do
   use ExUnit.Case
 
+  alias MixUnused.Analyzers.Unreachable.Usages.Context
   alias MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscovery
   alias MixUnused.Meta
 
   import Mock
 
-  # TODO: add alias
   test "it discovers http method handlers defined in controllers" do
     with_mock File,
       read!: fn "fooweb/router.ex" -> ~s[
@@ -25,13 +25,13 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscoveryTest do
         end
       ] end do
       usages =
-        PhoenixDiscovery.discover_usages(
+        PhoenixDiscovery.discover_usages(%Context{
           exports: %{
             {MyPhoenixApp.PageController, :index, 2} => %Meta{
               file: "fooweb/router.ex"
             }
           }
-        )
+        })
 
       assert {MyPhoenixApp.PageController, :index, 2} in usages
       assert {MyPhoenixApp.UsersController, :create_user, 2} in usages
@@ -67,11 +67,11 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscoveryTest do
         end
       | end do
       usages =
-        PhoenixDiscovery.discover_usages(
+        PhoenixDiscovery.discover_usages(%Context{
           exports: %{
             {MyPhoenixApp.PageController, :index, 2} => %Meta{file: "router.ex"}
           }
-        )
+        })
 
       assert {MyPhoenixPlug, :init, 1} in usages
       assert {MyPhoenixPlug, :call, 2} in usages

--- a/test/mix_unused/analyzers/unreachable/usages/phoenix_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/phoenix_discovery_test.exs
@@ -20,7 +20,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.PhoenixDiscoveryTest do
           scope "/" do
             get "/", MyPhoenixApp.PageController, :index
             post "/user", MyPhoenixApp.UsersController, :create_user
-            patch "/cart", CartController.Pippo, :update_cart
+            patch "/cart", CartController.Pippo, :update_cart, as: :cart
           end
         end
       ] end do

--- a/test/mix_unused/analyzers/unreachable/usages/supervisor_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/supervisor_discovery_test.exs
@@ -1,6 +1,7 @@
 defmodule MixUnused.Analyzers.Unreachable.Usages.SupervisorDiscoveryTest do
   use ExUnit.Case
 
+  alias MixUnused.Analyzers.Unreachable.Usages.Context
   alias MixUnused.Analyzers.Unreachable.Usages.SupervisorDiscovery
 
   alias MixUnused.Meta
@@ -31,7 +32,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.SupervisorDiscoveryTest do
         }
       end do
       usages =
-        SupervisorDiscovery.discover_usages(
+        SupervisorDiscovery.discover_usages(%Context{
           exports: %{
             {MyApp.AGenServer, :handle_call, 3} => %Meta{
               file: "a_genserver.ex"
@@ -41,7 +42,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.SupervisorDiscoveryTest do
               file: "supervisor.ex"
             }
           }
-        )
+        })
 
       assert {MyApp.MySupervisor, :init, 1} in usages
       assert {MyApp.AGenServer, :handle_call, 3} in usages

--- a/test/mix_unused/analyzers/unreachable/usages/vmstats_discovery_test.exs
+++ b/test/mix_unused/analyzers/unreachable/usages/vmstats_discovery_test.exs
@@ -10,7 +10,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.VmstatsDiscoveryTest do
       get_env: fn
         :vmstats, :sink -> VMStatsSink
       end do
-      usages = VmstatsDiscovery.discover_usages(any: "this is unused")
+      usages = VmstatsDiscovery.discover_usages(nil)
 
       assert {VMStatsSink, :collect, 3} in usages
       assert 1 == length(usages)
@@ -22,7 +22,7 @@ defmodule MixUnused.Analyzers.Unreachable.Usages.VmstatsDiscoveryTest do
       get_env: fn
         :vmstats, :sink -> nil
       end do
-      usages = VmstatsDiscovery.discover_usages(any: "this is unused")
+      usages = VmstatsDiscovery.discover_usages(nil)
 
       assert usages == []
     end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/MOTOR-1490

Adds the ExqDiscovery module.

In order to implement it I extended the `Aliases` and `Usages` module, then refactored the existing discovery modules as a consequence.

